### PR TITLE
修复ipad调用open方法没有效果的问题

### DIFF
--- a/ios/RNFileOpener/RNFileOpener.m
+++ b/ios/RNFileOpener/RNFileOpener.m
@@ -31,7 +31,10 @@ RCT_REMAP_METHOD(open, filePath:(NSString *)filePath fileMine:(NSString *)fileMi
     UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
     
     BOOL wasOpened = [self.FileOpener presentOpenInMenuFromRect:ctrl.view.bounds inView:ctrl.view animated:YES];
-    
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+    {
+        wasOpened = [self.FileOpener presentOptionsMenuFromRect:CGRectMake(CGRectGetMidX(ctrl.view.frame), CGRectGetMidY(ctrl.view.frame), 0, 20) inView:ctrl.view animated:YES];
+    }
     if (wasOpened) {
         resolve(@"Open success!!");
     } else {


### PR DESCRIPTION
if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
    {
        wasOpened = [self.FileOpener presentOptionsMenuFromRect:CGRectMake(CGRectGetMidX(ctrl.view.frame), CGRectGetMidY(ctrl.view.frame), 0, 20) inView:ctrl.view animated:YES];
    }